### PR TITLE
Reload, Config, Anti-Abuse

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -1,7 +1,5 @@
 # PVP Toggle
-Let your players choose on if they want pvp or not.
-
-When a player has pvp disabled they **can't get damaged by players** and also **can't damage players** themselves.
+Let your players choose when they want fight! When a player is protected, **they can't get damaged by other players** and also **can't damage other players themselves.**
 
 # Commands
  
@@ -9,3 +7,4 @@ When a player has pvp disabled they **can't get damaged by players** and also **
 |---------------|---------------------|------------------------|
 | `/pvp`        | Toggle pvp          | `pvptoggle.pvp`        |
 | `/pvp <user>` | Toggle pvp for user | `pvptoggle.pvp.others` |
+| `/pvp reload` | Reload the plugin   | `pvptoggle.reload`     |

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.lukeonuke</groupId>
     <artifactId>pvp-toggle</artifactId>
-    <version>1.2.0</version>
+    <version>1.3.0</version>
     <packaging>jar</packaging>
 
     <name>pvp-toggle</name>

--- a/src/main/java/com/lukeonuke/pvptoggle/PvpToggle.java
+++ b/src/main/java/com/lukeonuke/pvptoggle/PvpToggle.java
@@ -26,7 +26,7 @@ public final class PvpToggle extends JavaPlugin {
         OnDamageListener.spawnParticles = getConfig().getBoolean("particles", false);
         OnDamageListener.sendFeedback = getConfig().getBoolean("feedback", false);
         PvpCommand.cooldownDuration = getConfig().getInt("cooldown", 120);
-        PvpCommand.cooldownMessage = getConfig().getString("cooldown-message", "%s of cooldown remaining.")
+        PvpCommand.cooldownMessage = getConfig().getString("cooldown-message", "%s of cooldown remaining.");
         PvpService.cooldownDuration = getConfig().getInt("cooldown", 120);
         ChatFormatterService.prefix = getConfig().getString("prefix", "§4PVP »");
 

--- a/src/main/java/com/lukeonuke/pvptoggle/PvpToggle.java
+++ b/src/main/java/com/lukeonuke/pvptoggle/PvpToggle.java
@@ -1,9 +1,11 @@
 package com.lukeonuke.pvptoggle;
 
 import com.lukeonuke.pvptoggle.event.OnDamageListener;
+import com.lukeonuke.pvptoggle.service.ChatFormatterService;
 import com.lukeonuke.pvptoggle.service.PvpService;
 import lombok.Getter;
 import org.bukkit.Bukkit;
+import org.bukkit.ChatColor;
 import org.bukkit.plugin.Plugin;
 import org.bukkit.plugin.java.JavaPlugin;
 
@@ -11,20 +13,39 @@ import java.util.Objects;
 
 public final class PvpToggle extends JavaPlugin {
     @Getter
-    private static Plugin plugin = null;
+    public static Plugin plugin = null;
     @Override
     public void onEnable() {
         // Plugin startup logic
         plugin = this;
+
         saveDefaultConfig();
-        PvpService.setDefaultPvp(getConfig().getBoolean("default-pvp", false));
+        PvpService.defaultPvp = getConfig().getBoolean("default-pvp", false);
+        OnDamageListener.antiAbuse = getConfig().getBoolean("anti-abuse", true);
+        OnDamageListener.hitSelf = getConfig().getBoolean("hit-self", true);
+        OnDamageListener.spawnParticles = getConfig().getBoolean("particles", false);
+        OnDamageListener.sendFeedback = getConfig().getBoolean("feedback", false);
+        PvpCommand.cooldownDuration = getConfig().getInt("cooldown", 120);
+        PvpCommand.cooldownMessage = getConfig().getString("cooldown-message", "%s of cooldown remaining.")
+        PvpService.cooldownDuration = getConfig().getInt("cooldown", 120);
+        ChatFormatterService.prefix = getConfig().getString("prefix", "§4PVP »");
+
         Objects.requireNonNull(this.getCommand("pvp")).setExecutor(new PvpCommand());
-        Bukkit.getPluginManager().registerEvents(new OnDamageListener(getConfig().getString("pvp-off-message", "You can't PVP with %s!")), this);
-        plugin.getLogger().info("Registered successfully!");
+        Bukkit.getPluginManager().registerEvents(new OnDamageListener(getConfig().getString("pvp-off-message", "You can't fight %s!")), this);
+        plugin.getLogger().info("PVPToggle has been registered.");
     }
 
-    @Override
-    public void onDisable() {
-        // Plugin shutdown logic
+    public void reload() {
+        reloadConfig();
+        PvpService.defaultPvp = getConfig().getBoolean("default-pvp", false);
+        OnDamageListener.antiAbuse = getConfig().getBoolean("anti-abuse", true);
+        OnDamageListener.hitSelf = getConfig().getBoolean("hit-self", true);
+        OnDamageListener.spawnParticles = getConfig().getBoolean("particles", false);
+        OnDamageListener.sendFeedback = getConfig().getBoolean("feedback", false);
+        PvpCommand.cooldownDuration = getConfig().getInt("cooldown", 120);
+        PvpService.cooldownDuration = getConfig().getInt("cooldown", 120);
+        ChatFormatterService.prefix = getConfig().getString("prefix", "§4PVP »");
+
+        plugin.getLogger().info("PVPToggle has been reloaded.");
     }
 }

--- a/src/main/java/com/lukeonuke/pvptoggle/service/ChatFormatterService.java
+++ b/src/main/java/com/lukeonuke/pvptoggle/service/ChatFormatterService.java
@@ -3,11 +3,24 @@ package com.lukeonuke.pvptoggle.service;
 import org.bukkit.ChatColor;
 
 public class ChatFormatterService {
+    public static String prefix;
     public static String addPrefix(String text){
-        return ChatColor.DARK_RED + "[PVP TOGGLE] " + ChatColor.RESET + text;
+        return prefix + " " + ChatColor.RESET + text;
     }
 
     public static String booleanHumanReadable(boolean b){
-        return (b ? ChatColor.GREEN + "ON" : ChatColor.RED + "OFF") + ChatColor.RESET;
+        return (b ? ChatColor.RED + "Vulnerable" : ChatColor.GREEN + "Protected") + ChatColor.RESET;
+    }
+
+    public static String formatTime(long ms) {
+        long totalSeconds = ms / 1000;
+        long minutes = totalSeconds / 60;
+        long seconds = totalSeconds % 60;
+
+        if (minutes > 0) {
+            return minutes + " minute" + (minutes > 1 ? "s" : "") + " and " + seconds + " second" + (seconds != 1 ? "s" : "");
+        } else {
+            return seconds + " second" + (seconds != 1 ? "s" : "");
+        }
     }
 }

--- a/src/main/java/com/lukeonuke/pvptoggle/service/PvpService.java
+++ b/src/main/java/com/lukeonuke/pvptoggle/service/PvpService.java
@@ -12,21 +12,22 @@ import java.util.Objects;
 public class PvpService {
     private static final NamespacedKey isPvpEnabledKey = new NamespacedKey(PvpToggle.getPlugin(), "isPvpEnabled");
     private static final NamespacedKey pvpToggledTimestamp = new NamespacedKey(PvpToggle.getPlugin(), "pvpToggledTimestamp");
-    private static Boolean notDefaultPvp;
-    
-    public static void setDefaultPvp(boolean defaultPvp) {
-        PvpService.notDefaultPvp = !defaultPvp;
-    }
-    
+    public static Boolean defaultPvp;
+    public static Integer cooldownDuration;
+
     public static boolean isPvpDisabled(Player player) {
         PersistentDataContainer dataContainer = player.getPersistentDataContainer();
-        // By equating to true we ensure that the data isn't null.
-        return notDefaultPvp.equals(dataContainer.get(isPvpEnabledKey, PersistentDataType.BOOLEAN));
+        return !defaultPvp.equals(dataContainer.get(isPvpEnabledKey, PersistentDataType.BOOLEAN));
     }
 
     public static void setPvpEnabled(Player player, boolean enabled) {
         PersistentDataContainer dataContainer = player.getPersistentDataContainer();
-        dataContainer.set(isPvpEnabledKey, PersistentDataType.BOOLEAN, enabled);
+        dataContainer.set(isPvpEnabledKey, PersistentDataType.BOOLEAN, !enabled);
+        dataContainer.set(pvpToggledTimestamp, PersistentDataType.LONG, Instant.now().toEpochMilli());
+    }
+
+    public static void setPvpCooldownTimestamp(Player player) {
+        PersistentDataContainer dataContainer = player.getPersistentDataContainer();
         dataContainer.set(pvpToggledTimestamp, PersistentDataType.LONG, Instant.now().toEpochMilli());
     }
 
@@ -39,6 +40,6 @@ public class PvpService {
     }
 
     public static boolean isPvpCooldownDone(Player player) {
-        return Instant.now().isAfter(Instant.ofEpochMilli(getPvpCooldownTimestamp(player).toEpochMilli() + 5000));
+        return Instant.now().isAfter(Instant.ofEpochMilli(getPvpCooldownTimestamp(player).toEpochMilli() + cooldownDuration * 1000));
     }
 }

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -10,6 +10,7 @@ prefix: "§4PVP »"
 default-pvp: false
 
 # What is the message sent to players in the chat if they try to use the pvp command while on cooldown?
+# %s is replaced by the time remaining, in the format of "1 minute and 32 seconds" or "32 seconds"
 cooldown-message: "%s of cooldown remaining."
 
 # After enabling pvp, how long must a player wait before disabling it?

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -1,5 +1,28 @@
-# Default pvp on/off
+# What should the message be when a player tries to attack someone but fails because they're protected?
+# %s is replaced by damaged player's name.
+pvp-off-message: "You can't fight %s!"
+
+# What should messages be prefixed with?
+# You can use the formatting codes listed at https://minecraft.wiki/w/Formatting_codes#Color_codes
+prefix: "§4PVP »"
+
+# Should pvp be on by default?
 default-pvp: false
-# Message displayed when trying to pvp while one has pvp toggled off
-# %s is replaced by damaged player name
-pvp-off-message: "You can't PVP with %s!"
+
+# What is the message sent to players in the chat if they try to use the pvp command while on cooldown?
+cooldown-message: "%s of cooldown remaining."
+
+# After enabling pvp, how long must a player wait before disabling it?
+cooldown: 120
+
+# Should players be prevented from disabling pvp during a fight?
+anti-abuse: true
+
+# Should players be able to hit themselves?
+hit-self: true
+
+# Should particles be spawned when a player is hit, but protected?
+particles: false
+
+# Should a message be sent to a player when they hit another player, but fail because that player is protected?
+feedback: true

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -1,13 +1,19 @@
-name: pvp-toggle
+name: PVPToggle
 version: '${project.version}'
 main: com.lukeonuke.pvptoggle.PvpToggle
 api-version: '1.20'
 commands:
   pvp:
-    description: "Toggle pvp"
+    description: "Allow players to toggle PVP individually."
     usage: /<command>
     permission: pvptoggle.pvp
 permissions :
   pvptoggle.pvp.others:
-    description: "Allows the player to toggle pvp of other players"
+    description: "Allows the player to toggle PVP for other players."
+    default: op
+  pvptoggle.pvp:
+    description: "Allows the player to toggle their own PVP."
+    default: true
+  pvptoggle.reload:
+    description: "Reload the plugin."
     default: op


### PR DESCRIPTION
Here's my second attempt at a pull request. I've tested it and it seems to works, but I certainly recommend that you test it too. I've added
- Much more configuration
- An option to prevent players from using `/pvp` to escape a battle by resetting the cooldown when they're hit
- Better formatters, including more readable language and a time formatter that can do minutes
- The `/pvp reload` command which reloads the configuration
- Slightly Better documentation (in my opinion)
- The cooldown only applies when going from being protected to vulnerable, not the other way around.