### PR TITLE
Protect players on death

### DIFF
--- a/src/main/java/com/lukeonuke/pvptoggle/PvpCommand.java
+++ b/src/main/java/com/lukeonuke/pvptoggle/PvpCommand.java
@@ -18,7 +18,7 @@ public class PvpCommand implements CommandExecutor{
 
     @Override
     public boolean onCommand(
-            @NotNull CommandSender commandSender, 
+            @NotNull CommandSender commandSender,
             @NotNull Command command,
             @NotNull String s,
             String[] args) {

--- a/src/main/java/com/lukeonuke/pvptoggle/PvpToggle.java
+++ b/src/main/java/com/lukeonuke/pvptoggle/PvpToggle.java
@@ -1,11 +1,11 @@
 package com.lukeonuke.pvptoggle;
 
 import com.lukeonuke.pvptoggle.event.OnDamageListener;
+import com.lukeonuke.pvptoggle.event.OnPlayerDeathListener;
 import com.lukeonuke.pvptoggle.service.ChatFormatterService;
 import com.lukeonuke.pvptoggle.service.PvpService;
 import lombok.Getter;
 import org.bukkit.Bukkit;
-import org.bukkit.ChatColor;
 import org.bukkit.plugin.Plugin;
 import org.bukkit.plugin.java.JavaPlugin;
 
@@ -20,6 +20,21 @@ public final class PvpToggle extends JavaPlugin {
         plugin = this;
 
         saveDefaultConfig();
+        load();
+
+        Objects.requireNonNull(this.getCommand("pvp")).setExecutor(new PvpCommand());
+        Bukkit.getPluginManager().registerEvents(new OnDamageListener(getConfig().getString("pvp-off-message", "You can't fight %s!")), this);
+        Bukkit.getPluginManager().registerEvents(new OnPlayerDeathListener(), this);
+        plugin.getLogger().info("PVPToggle has been registered.");
+    }
+
+    public void reload() {
+        reloadConfig();
+        load();
+        plugin.getLogger().info("PVPToggle has been reloaded.");
+    }
+
+    private void load() {
         PvpService.defaultPvp = getConfig().getBoolean("default-pvp", false);
         OnDamageListener.antiAbuse = getConfig().getBoolean("anti-abuse", true);
         OnDamageListener.hitSelf = getConfig().getBoolean("hit-self", true);
@@ -28,24 +43,12 @@ public final class PvpToggle extends JavaPlugin {
         PvpCommand.cooldownDuration = getConfig().getInt("cooldown", 120);
         PvpCommand.cooldownMessage = getConfig().getString("cooldown-message", "%s of cooldown remaining.");
         PvpService.cooldownDuration = getConfig().getInt("cooldown", 120);
+        OnPlayerDeathListener.cooldownDuration = getConfig().getInt("cooldown", 120);
         ChatFormatterService.prefix = getConfig().getString("prefix", "§4PVP »");
-
-        Objects.requireNonNull(this.getCommand("pvp")).setExecutor(new PvpCommand());
-        Bukkit.getPluginManager().registerEvents(new OnDamageListener(getConfig().getString("pvp-off-message", "You can't fight %s!")), this);
-        plugin.getLogger().info("PVPToggle has been registered.");
-    }
-
-    public void reload() {
-        reloadConfig();
-        PvpService.defaultPvp = getConfig().getBoolean("default-pvp", false);
-        OnDamageListener.antiAbuse = getConfig().getBoolean("anti-abuse", true);
-        OnDamageListener.hitSelf = getConfig().getBoolean("hit-self", true);
-        OnDamageListener.spawnParticles = getConfig().getBoolean("particles", false);
-        OnDamageListener.sendFeedback = getConfig().getBoolean("feedback", false);
-        PvpCommand.cooldownDuration = getConfig().getInt("cooldown", 120);
-        PvpService.cooldownDuration = getConfig().getInt("cooldown", 120);
-        ChatFormatterService.prefix = getConfig().getString("prefix", "§4PVP »");
-
-        plugin.getLogger().info("PVPToggle has been reloaded.");
+        OnPlayerDeathListener.deathStatusReset = getConfig().getBoolean("death-status-reset", true);
+        OnPlayerDeathListener.deathStatus = getConfig().getBoolean("death-status", false);
+        OnPlayerDeathListener.deathCooldownReset = getConfig().getBoolean("death-cooldown-reset", true);
+        OnPlayerDeathListener.deathCooldown = getConfig().getInt("death-cooldown", 0);
+        OnPlayerDeathListener.deathMessage = getConfig().getBoolean("death-message", true);
     }
 }

--- a/src/main/java/com/lukeonuke/pvptoggle/PvpToggle.java
+++ b/src/main/java/com/lukeonuke/pvptoggle/PvpToggle.java
@@ -52,6 +52,7 @@ public final class PvpToggle extends JavaPlugin {
         OnPlayerDeathListener.deathMessage = getConfig().getBoolean("death-message", true);
         OnDamageListener.protectPets = getConfig().getBoolean("protect-pets", true);
         OnDamageListener.petPvpMessage = getConfig().getString("pet-pvp-message", "You can't fight %s's pet!");
-        OnDamageListener.hitPets = getConfig().getBoolean("hit-pets", false);
+        OnDamageListener.friendlyFire = getConfig().getBoolean("friendly-fire", false);
+        OnDamageListener.ffMessage = getConfig().getString("ff-message", "Friendly fire!");
     }
 }

--- a/src/main/java/com/lukeonuke/pvptoggle/PvpToggle.java
+++ b/src/main/java/com/lukeonuke/pvptoggle/PvpToggle.java
@@ -50,5 +50,8 @@ public final class PvpToggle extends JavaPlugin {
         OnPlayerDeathListener.deathCooldownReset = getConfig().getBoolean("death-cooldown-reset", true);
         OnPlayerDeathListener.deathCooldown = getConfig().getInt("death-cooldown", 0);
         OnPlayerDeathListener.deathMessage = getConfig().getBoolean("death-message", true);
+        OnDamageListener.protectPets = getConfig().getBoolean("protect-pets", true);
+        OnDamageListener.petPvpMessage = getConfig().getString("pet-pvp-message", "You can't fight %s's pet!");
+        OnDamageListener.hitPets = getConfig().getBoolean("hit-pets", false);
     }
 }

--- a/src/main/java/com/lukeonuke/pvptoggle/event/OnDamageListener.java
+++ b/src/main/java/com/lukeonuke/pvptoggle/event/OnDamageListener.java
@@ -1,6 +1,5 @@
 package com.lukeonuke.pvptoggle.event;
 
-import com.lukeonuke.pvptoggle.PvpToggle;
 import com.lukeonuke.pvptoggle.service.ChatFormatterService;
 import com.lukeonuke.pvptoggle.service.PvpService;
 import net.md_5.bungee.api.ChatMessageType;
@@ -11,6 +10,7 @@ import org.bukkit.entity.*;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
 import org.bukkit.event.entity.EntityDamageByEntityEvent;
+import org.jetbrains.annotations.NotNull;
 
 import java.util.Objects;
 
@@ -68,13 +68,27 @@ public class OnDamageListener implements Listener {
         if (event.isCancelled() && Objects.nonNull(damager)) {
             if (spawnParticles && pet != null) damager.spawnParticle(Particle.CAMPFIRE_COSY_SMOKE, pet.getLocation(), 10);
             else damager.spawnParticle(Particle.CAMPFIRE_COSY_SMOKE, player.getLocation(), 10);
-            if (sendFeedback && pet != null) damager.spigot().sendMessage(ChatMessageType.ACTION_BAR, TextComponent.fromLegacyText((ChatFormatterService.addPrefix(petPvpMessage.replace("%s", player.getDisplayName() + ChatColor.RESET)))));
-            else damager.spigot().sendMessage(ChatMessageType.ACTION_BAR, TextComponent.fromLegacyText((ChatFormatterService.addPrefix(feedbackMessage.replace("%s", player.getDisplayName() + ChatColor.RESET)))));
+            TextComponent actionBarMessage = getActionBarMessage(pet, player);
+            damager.spigot().sendMessage(ChatMessageType.ACTION_BAR, actionBarMessage);
         }
 
         // If a player is hit by another player, is vulnerable, and anti-abuse is true, restart the damaged player's cooldown.
         if (!event.isCancelled() && antiAbuse) {
             PvpService.setPvpCooldownTimestamp(player);
         }
+    }
+
+    private static @NotNull TextComponent getActionBarMessage(Tameable pet, Player player) {
+        String message;
+        if (sendFeedback && pet != null) {
+            message = ChatFormatterService.addPrefix(
+                    petPvpMessage.replace("%s", player.getDisplayName() + ChatColor.RESET)
+            );
+        } else {
+            message = ChatFormatterService.addPrefix(
+                    feedbackMessage.replace("%s", player.getDisplayName() + ChatColor.RESET)
+            );
+        }
+        return new TextComponent(message);
     }
 }

--- a/src/main/java/com/lukeonuke/pvptoggle/event/OnDamageListener.java
+++ b/src/main/java/com/lukeonuke/pvptoggle/event/OnDamageListener.java
@@ -92,11 +92,7 @@ public class OnDamageListener implements Listener {
         // If attack is cancelled, handle feedback and particles
         if (event.isCancelled() && damager != null) {
             if (spawnParticles) {
-                if (pet != null) {
-                    damager.spawnParticle(Particle.CAMPFIRE_COSY_SMOKE, pet.getLocation(), 10);
-                } else {
-                    damager.spawnParticle(Particle.CAMPFIRE_COSY_SMOKE, player.getLocation(), 10);
-                }
+                damager.spawnParticle(Particle.CAMPFIRE_COSY_SMOKE, Objects.requireNonNullElse(pet, player).getLocation(), 10);
             }
 
             // Send feedback message to the attacker

--- a/src/main/java/com/lukeonuke/pvptoggle/event/OnDamageListener.java
+++ b/src/main/java/com/lukeonuke/pvptoggle/event/OnDamageListener.java
@@ -7,8 +7,7 @@ import net.md_5.bungee.api.ChatMessageType;
 import net.md_5.bungee.api.chat.TextComponent;
 import org.bukkit.ChatColor;
 import org.bukkit.Particle;
-import org.bukkit.entity.Player;
-import org.bukkit.entity.Projectile;
+import org.bukkit.entity.*;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
 import org.bukkit.event.entity.EntityDamageByEntityEvent;
@@ -21,6 +20,9 @@ public class OnDamageListener implements Listener {
     public static Boolean sendFeedback;
     public static Boolean hitSelf;
     public static Boolean spawnParticles;
+    public static Boolean protectPets;
+    public static Boolean hitPets;
+    public static String petPvpMessage;
 
     public OnDamageListener(String feedbackMessage) {
         OnDamageListener.feedbackMessage = feedbackMessage;
@@ -28,7 +30,16 @@ public class OnDamageListener implements Listener {
 
     @EventHandler()
     public void onHit(EntityDamageByEntityEvent event) {
-        if(!(event.getEntity() instanceof Player player)) return;
+        Entity entity = event.getEntity();
+        Player player;
+        Tameable pet = null;
+        if (entity instanceof Tameable) {
+            pet = (Tameable) entity;
+            if (pet.getOwner() instanceof Player) {
+                player = (Player) pet.getOwner();
+            } else return;
+        } else if (!(entity instanceof Player)) return;
+        else player = (Player) entity;
         Player damager = null;
         if (event.getDamager() instanceof Player damagerLocal
                 && (PvpService.isPvpDisabled(damagerLocal) || PvpService.isPvpDisabled(player))) {
@@ -37,17 +48,28 @@ public class OnDamageListener implements Listener {
         }
 
         // If a player hits themselves and hit-self is true, make them take damage.
-        if (event.getDamager() instanceof Projectile projectile && projectile.getShooter() instanceof Player projectileOwner && hitSelf) {
-            damager = projectileOwner;
-            if (player.equals(projectileOwner)) return;
-            if (PvpService.isPvpDisabled(player)) event.setCancelled(true);
-            if (PvpService.isPvpDisabled(projectileOwner)) event.setCancelled(true);
+        // If a player hit their pet and hit-pets is true, make them take damage.
+        if (pet != null && damager != null) {
+            // if the attacked is a pet, and the attacker is the pet's owner, and you can hit your own pets:
+            event.setCancelled(!(damager.equals(player) && hitPets));
+        } else {
+            // if attacker is a projectile, and the projectile's shooter is a player, and you can hit yourself:
+            if (event.getDamager() instanceof Projectile projectile && projectile.getShooter() instanceof Player projectileOwner && hitSelf) {
+                damager = projectileOwner;
+                // if the attacked player is equal to the attacking player, return.
+                if (player.equals(projectileOwner)) return;
+                // otherwise, if pvp is disabled for either player, cancel the attack.
+                if (PvpService.isPvpDisabled(player)) event.setCancelled(true);
+                if (PvpService.isPvpDisabled(projectileOwner)) event.setCancelled(true);
+            }
         }
 
         // If a player is hit by another player, but is protected, spawn particles and send a message to the attacker.
         if (event.isCancelled() && Objects.nonNull(damager)) {
-            if (spawnParticles) damager.spawnParticle(Particle.CAMPFIRE_COSY_SMOKE, player.getLocation(), 10);
-            if (sendFeedback) damager.spigot().sendMessage(ChatMessageType.ACTION_BAR, TextComponent.fromLegacyText((ChatFormatterService.addPrefix(feedbackMessage.replace("%s", player.getDisplayName() + ChatColor.RESET)))));
+            if (spawnParticles && pet != null) damager.spawnParticle(Particle.CAMPFIRE_COSY_SMOKE, pet.getLocation(), 10);
+            else damager.spawnParticle(Particle.CAMPFIRE_COSY_SMOKE, player.getLocation(), 10);
+            if (sendFeedback && pet != null) damager.spigot().sendMessage(ChatMessageType.ACTION_BAR, TextComponent.fromLegacyText((ChatFormatterService.addPrefix(petPvpMessage.replace("%s", player.getDisplayName() + ChatColor.RESET)))));
+            else damager.spigot().sendMessage(ChatMessageType.ACTION_BAR, TextComponent.fromLegacyText((ChatFormatterService.addPrefix(feedbackMessage.replace("%s", player.getDisplayName() + ChatColor.RESET)))));
         }
 
         // If a player is hit by another player, is vulnerable, and anti-abuse is true, restart the damaged player's cooldown.

--- a/src/main/java/com/lukeonuke/pvptoggle/event/OnPlayerDeathListener.java
+++ b/src/main/java/com/lukeonuke/pvptoggle/event/OnPlayerDeathListener.java
@@ -1,0 +1,41 @@
+package com.lukeonuke.pvptoggle.event;
+
+import com.lukeonuke.pvptoggle.PvpToggle;
+import com.lukeonuke.pvptoggle.service.ChatFormatterService;
+import com.lukeonuke.pvptoggle.service.PvpService;
+import org.bukkit.NamespacedKey;
+import org.bukkit.entity.Player;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+import org.bukkit.event.entity.PlayerDeathEvent;
+import org.bukkit.persistence.PersistentDataContainer;
+import org.bukkit.persistence.PersistentDataType;
+
+import java.time.Instant;
+
+public class OnPlayerDeathListener implements Listener {
+    public static Boolean deathStatusReset;
+    public static Boolean deathStatus;
+    public static Boolean deathCooldownReset;
+    public static Integer deathCooldown;
+    public static Integer cooldownDuration;
+    public static Boolean deathMessage;
+
+    private static final NamespacedKey pvpToggledTimestamp = new NamespacedKey(PvpToggle.getPlugin(), "pvpToggledTimestamp");
+
+    @EventHandler()
+    public void onDeath(PlayerDeathEvent event) {
+        Player player = event.getEntity();
+        if (deathStatusReset) {
+            PvpService.setPvpEnabled(player, deathStatus);
+            if (deathMessage) {
+                boolean isPvpEnabled = PvpService.isPvpDisabled(player);
+                player.sendMessage(ChatFormatterService.addPrefix("You are now " + ChatFormatterService.booleanHumanReadable(!isPvpEnabled)));
+            }
+        }
+        if (deathCooldownReset) {
+            PersistentDataContainer dataContainer = player.getPersistentDataContainer();
+            dataContainer.set(pvpToggledTimestamp, PersistentDataType.LONG, Instant.now().toEpochMilli() - cooldownDuration * 1000 + deathCooldown * 1000);
+        }
+    }
+}

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -1,7 +1,6 @@
 # What should the message be when a player tries to attack someone but fails because they're protected?
 # %s is replaced by damaged player's name.
 pvp-off-message: "You can't fight %s!"
-
 pet-pvp-message: "You can't fight %s's pet!"
 
 # What should messages be prefixed with?
@@ -48,5 +47,8 @@ death-message: true
 # Should players be able to attack pets of protected players?
 protect-pets: true
 
-# Should players be able to hit their own pets?
-hit-pets: false
+# Should players ever be able to hit their own pets? (More "friendlies" coming soon)
+friendly-fire: false
+
+# What should the message be when you try to attack your own team, but fail because friendly-fire is false?
+ff-message: "Friendly fire!"

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -24,7 +24,7 @@ anti-abuse: true
 hit-self: true
 
 # Should particles be spawned when a player is hit, but protected?
-particles: true
+particles: false
 
 # Should a message be sent to a player when they hit another player, but fail because that player is protected?
 feedback: true

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -4,7 +4,7 @@ pvp-off-message: "You can't fight %s!"
 
 # What should messages be prefixed with?
 # You can use the formatting codes listed at https://minecraft.wiki/w/Formatting_codes#Color_codes
-prefix: "§4PVP »"
+prefix: "§4PvP »"
 
 # Should pvp be on by default?
 default-pvp: false
@@ -13,7 +13,7 @@ default-pvp: false
 # %s is replaced by the time remaining, in the format of "1 minute and 32 seconds" or "32 seconds"
 cooldown-message: "%s of cooldown remaining."
 
-# After enabling pvp, how long must a player wait before disabling it?
+# After enabling pvp, how many seconds must a player wait before disabling it?
 cooldown: 120
 
 # Should players be prevented from disabling pvp during a fight?
@@ -27,3 +27,18 @@ particles: false
 
 # Should a message be sent to a player when they hit another player, but fail because that player is protected?
 feedback: true
+
+# Should a player's pvp status be reset when they die?
+death-status-reset: true
+
+# Should pvp be turned on after a player dies? Doesn't apply if death-status-reset is false.
+death-status: false
+
+# Should a player's cooldown be reset when they die?
+death-cooldown-reset: true
+
+# How many seconds should a player's cooldown be set to when they die? Doesn't apply if death-cooldown-reset is false.
+death-cooldown: 0
+
+# Should a player be sent a chat message when they die?
+death-message: true

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -2,6 +2,8 @@
 # %s is replaced by damaged player's name.
 pvp-off-message: "You can't fight %s!"
 
+pet-pvp-message: "You can't fight %s's pet!"
+
 # What should messages be prefixed with?
 # You can use the formatting codes listed at https://minecraft.wiki/w/Formatting_codes#Color_codes
 prefix: "§4PvP »"
@@ -23,7 +25,7 @@ anti-abuse: true
 hit-self: true
 
 # Should particles be spawned when a player is hit, but protected?
-particles: false
+particles: true
 
 # Should a message be sent to a player when they hit another player, but fail because that player is protected?
 feedback: true
@@ -42,3 +44,9 @@ death-cooldown: 0
 
 # Should a player be sent a chat message when they die?
 death-message: true
+
+# Should players be able to attack pets of protected players?
+protect-pets: true
+
+# Should players be able to hit their own pets?
+hit-pets: false


### PR DESCRIPTION
Hello, again! Since I added the anti-abuse option to prevent players from disabling pvp during a fight, I've been worried abuot spawn killing. So, I added an option to automatically disable pvp or set the cooldown to 0 (or another number) when a player is killed. In addition, I've made a small update to the load-reload system to remove duplicated code.